### PR TITLE
feat: create root pyproject.toml for uv workspace

### DIFF
--- a/packages/horn-core/pyproject.toml
+++ b/packages/horn-core/pyproject.toml
@@ -6,5 +6,6 @@ dependencies = [
     "numpy"
 ]
 
-[tool.uv.sources]
-horn-core = { path = "." } 
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/packages/horn-solver/pyproject.toml
+++ b/packages/horn-solver/pyproject.toml
@@ -16,4 +16,8 @@ horn-solver = "horn_solver.solver:main"
 [project.optional-dependencies]
 test = [
     "pytest>=8.2.2"
-] 
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build" 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "horn-simulation"
+version = "0.1.0"
+description = "Horn loudspeaker simulation pipeline"
+requires-python = ">=3.10"
+
+[tool.uv.workspace]
+members = [
+    "packages/horn-core",
+    "packages/horn-geometry",
+    "packages/horn-solver",
+    "packages/horn-analysis",
+]


### PR DESCRIPTION
## Summary
- Create root `pyproject.toml` defining a uv workspace with the 4 active packages (`horn-core`, `horn-geometry`, `horn-solver`, `horn-analysis`)
- Remove broken self-referential `[tool.uv.sources]` entry in `horn-core/pyproject.toml` (fixes #26)
- Add missing `[build-system]` with hatchling to `horn-core` and `horn-solver` for consistency with other packages

Closes #8, closes #26

## Test plan
- [x] `uv sync --dry-run` resolves 49 packages successfully from repo root
- [ ] Verify existing Docker-based CI is unaffected (Dockerfiles install packages directly with pip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)