### PR TITLE
fix: FEM-only pipeline correctness

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -45,10 +45,10 @@ process run_simulation {
     path "results_${band_index}.csv"
 
     script:
-    def band_width = (params.max_freq - params.min_freq) / params.num_bands
+    def band_width = (params.max_freq - params.min_freq) / (params.num_bands as double)
     def min_f = params.min_freq + band_width * band_index
     def max_f = params.min_freq + band_width * (band_index + 1)
-    def num_intervals_per_band = params.num_intervals / params.num_bands
+    def num_intervals_per_band = Math.ceil(params.num_intervals / (params.num_bands as double)) as int
     """
     echo "Running band ${band_index}: ${min_f} Hz to ${max_f} Hz"
     python3 -m horn_solver.solver \
@@ -56,8 +56,9 @@ process run_simulation {
         --output-file results_${band_index}.csv \
         --min-freq ${min_f} \
         --max-freq ${max_f} \
-        --num-intervals ${num_intervals_per_band as int} \
-        --length ${params.length}
+        --num-intervals ${num_intervals_per_band} \
+        --length ${params.length} \
+        --mesh-size ${params.mesh_size}
     """
 }
 

--- a/packages/horn-geometry/tests/test_cli_smoke.py
+++ b/packages/horn-geometry/tests/test_cli_smoke.py
@@ -26,7 +26,7 @@ def test_generator_creates_step_file_smoke_test(tmp_path):
         throat_radius=0.025,
         mouth_radius=0.25,
         length=0.35,
-        output_dir=output_dir,
+        output_file=output_dir / "horn.step",
     )
 
     # Assert the file was created

--- a/packages/horn-geometry/tests/test_conical_horn.py
+++ b/packages/horn-geometry/tests/test_conical_horn.py
@@ -34,7 +34,7 @@ class TestConicalHornValidation:
         """
         output_dir = tmp_path_factory.mktemp("horn_test")
         step_file = create_conical_horn(
-            output_dir=output_dir,
+            output_file=output_dir / "horn.step",
             **horn_parameters
         )
         # Load the shape from the generated STEP file

--- a/packages/horn-solver/Dockerfile
+++ b/packages/horn-solver/Dockerfile
@@ -9,7 +9,7 @@ FROM base as production
 # bempp-cl 0.4+ renamed the module from 'bempp' to 'bempp_cl'; our code
 # uses 'import bempp.api' so we need <0.4.
 RUN pip install 'bempp-cl<0.4'
-RUN pip install --ignore-installed gmsh
+# gmsh is already provided by the dolfinx base image (system package)
 
 # Set up the entrypoint to activate complex mode.
 COPY ./packages/horn-solver/entrypoint.sh /usr/local/bin/

--- a/packages/horn-solver/tests/test_solver.py
+++ b/packages/horn-solver/tests/test_solver.py
@@ -31,7 +31,6 @@ def test_mesh_boundary_tagging():
 
     print("--- Test finished ---\n")
 
-@pytest.mark.xfail(reason="bempp.x.dolfinx coupling layer not available in bempp-cl<0.4")
 def test_e2e_meshing_and_solving(tmp_path):
     print("\n--- Running test: test_e2e_meshing_and_solving ---\n")
     # This test uses a pre-generated STEP file to avoid a dependency on FreeCAD
@@ -86,7 +85,6 @@ def test_e2e_meshing_and_solving(tmp_path):
     print(f"Successfully created plot: {plot_image_file}")
     print("--- Test finished ---")
 
-@pytest.mark.xfail(reason="bempp.x.dolfinx coupling layer not available in bempp-cl<0.4")
 def test_e2e_with_bem(tmp_path):
     print("\n--- Running test: test_e2e_with_bem ---\n")
     step_file = Path(__file__).parent / "test_box.stp"


### PR DESCRIPTION
## Summary

- **Remove broken BEM call** from frequency loop — it crashed on every invocation (`bempp.x.dolfinx` doesn't exist), making the solver completely non-functional
- **Fix SPL calculation** — replace meaningless volume L2 norm with outlet-surface RMS pressure integral (`ufl.ds` with subdomain markers)
- **Add frequency-adaptive meshing** — mesh element size adapts to `λ/6 = c/(6·f_max)` criterion per band
- **Forward `--mesh-size` param** from Nextflow to solver CLI (was defined but never passed)
- **Fix Groovy integer division** — `100/8 = 12` was silently dropping 4 frequency points; now uses `Math.ceil` with float division
- **Fix test kwargs** — `output_dir` → `output_file` to match `create_conical_horn()` signature
- **Fix Dockerfile** — remove `pip install --ignore-installed gmsh` that fails on ARM (gmsh is already in the dolfinx base image)

Closes #4, #10, #11, #12, #14, #40

## Test plan

- [x] `just test-package horn-solver` — 4 passed (mesh tagging, e2e solving, e2e with BEM, plane wave physics)
- [ ] CI passes on push (horn-geometry/horn-analysis have pre-existing ARM Docker build issues unrelated to this PR)
- [ ] Manual smoke test: `nextflow run main.nf -profile docker --num_intervals 10 --num_bands 2` produces plausible SPL values

🤖 Generated with [Claude Code](https://claude.com/claude-code)