### PR TITLE
feat: Phase 3 — horn profiles + analysis features

### DIFF
--- a/packages/horn-analysis/pyproject.toml
+++ b/packages/horn-analysis/pyproject.toml
@@ -10,6 +10,10 @@ dependencies = [
 
 [project.scripts]
 horn-plotter = "horn_analysis.plotter:main"
+horn-kpi = "horn_analysis.kpi:main"
+horn-compare = "horn_analysis.compare:main"
+horn-impedance-plot = "horn_analysis.impedance_plot:main"
+horn-phase-plot = "horn_analysis.phase_plot:main"
 
 [project.optional-dependencies]
 test = [

--- a/packages/horn-analysis/src/horn_analysis/compare.py
+++ b/packages/horn-analysis/src/horn_analysis/compare.py
@@ -1,0 +1,116 @@
+"""Multi-horn frequency response comparison with optional KPI table.
+
+Generalizes compare_horns.py to N files. Accepts labeled file pairs
+via CLI: --files a.csv:Label b.csv:Label ...
+"""
+
+import argparse
+from pathlib import Path
+from typing import List, Tuple, Optional
+
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+def plot_multi_comparison(
+    file_label_pairs: List[Tuple[str, str]],
+    output_file: str,
+    kpi_table: bool = False,
+) -> Path:
+    """Plot N frequency responses on the same axes.
+
+    Args:
+        file_label_pairs: List of (csv_path, label) tuples.
+        output_file: Output image path.
+        kpi_table: If True, add a KPI summary table below the plot.
+
+    Returns:
+        Path to the output image.
+    """
+    if kpi_table:
+        fig, (ax_plot, ax_table) = plt.subplots(
+            2, 1, figsize=(12, 10), gridspec_kw={"height_ratios": [3, 1]},
+        )
+    else:
+        fig, ax_plot = plt.subplots(figsize=(12, 8))
+
+    for csv_path, label in file_label_pairs:
+        df = pd.read_csv(csv_path)
+        ax_plot.plot(df["frequency"], df["spl"], label=label)
+
+    ax_plot.set_xscale("log")
+    ax_plot.set_title("Horn Frequency Response Comparison")
+    ax_plot.set_xlabel("Frequency (Hz)")
+    ax_plot.set_ylabel("Sound Pressure Level (dB)")
+    ax_plot.grid(True, which="both", ls="--")
+    ax_plot.legend()
+
+    if kpi_table:
+        from horn_analysis.kpi import extract_kpis
+
+        rows = []
+        for csv_path, label in file_label_pairs:
+            kpis = extract_kpis(csv_path)
+            rows.append([
+                label,
+                f"{kpis.peak_spl_db:.1f}",
+                f"{kpis.peak_frequency_hz:.0f}",
+                f"{kpis.f3_low_hz:.0f}" if kpis.f3_low_hz else "—",
+                f"{kpis.f3_high_hz:.0f}" if kpis.f3_high_hz else "—",
+                f"{kpis.bandwidth_octaves:.1f}" if kpis.bandwidth_octaves else "—",
+                f"{kpis.passband_ripple_db:.1f}" if kpis.passband_ripple_db is not None else "—",
+                f"{kpis.average_sensitivity_db:.1f}" if kpis.average_sensitivity_db is not None else "—",
+            ])
+
+        col_labels = [
+            "Horn", "Peak (dB)", "Peak Freq (Hz)",
+            "f3 Low (Hz)", "f3 High (Hz)", "BW (oct)",
+            "Ripple (dB)", "Avg Sens (dB)",
+        ]
+
+        ax_table.axis("off")
+        table = ax_table.table(
+            cellText=rows,
+            colLabels=col_labels,
+            loc="center",
+            cellLoc="center",
+        )
+        table.auto_set_font_size(False)
+        table.set_fontsize(9)
+        table.scale(1, 1.4)
+
+    plt.tight_layout()
+    output_path = Path(output_file)
+    plt.savefig(output_path, dpi=150)
+    plt.close()
+    print(f"Comparison plot saved to {output_path}")
+    return output_path
+
+
+def parse_file_label(s: str) -> Tuple[str, str]:
+    """Parse 'path.csv:Label' into (path, label). If no colon, use filename as label."""
+    if ":" in s:
+        path, label = s.rsplit(":", 1)
+        return path, label
+    return s, Path(s).stem
+
+
+def main():
+    """CLI for multi-horn comparison."""
+    parser = argparse.ArgumentParser(description="Compare N horn frequency responses.")
+    parser.add_argument(
+        "--files", nargs="+", required=True,
+        help="CSV files with optional labels: file.csv:Label",
+    )
+    parser.add_argument("--output", type=str, default="comparison.png", help="Output image path.")
+    parser.add_argument("--kpi-table", action="store_true", help="Add KPI summary table.")
+    args = parser.parse_args()
+
+    pairs = [parse_file_label(f) for f in args.files]
+    plot_multi_comparison(pairs, args.output, kpi_table=args.kpi_table)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/horn-analysis/src/horn_analysis/impedance_plot.py
+++ b/packages/horn-analysis/src/horn_analysis/impedance_plot.py
@@ -1,0 +1,67 @@
+"""Throat impedance plotting: |Z| and angle(Z) vs frequency on dual y-axes."""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+def plot_impedance(csv_file: str, output_file: str):
+    """Plot throat impedance magnitude and phase from solver CSV output.
+
+    Expects CSV columns: frequency, z_real, z_imag.
+
+    Args:
+        csv_file: Input CSV path.
+        output_file: Output image path.
+    """
+    df = pd.read_csv(csv_file)
+    freq = df["frequency"].values
+    z_complex = df["z_real"].values + 1j * df["z_imag"].values
+
+    z_mag = np.abs(z_complex)
+    z_angle = np.degrees(np.angle(z_complex))
+
+    fig, ax1 = plt.subplots(figsize=(10, 6))
+
+    color_mag = "tab:blue"
+    ax1.set_xlabel("Frequency (Hz)")
+    ax1.set_ylabel("|Z| (Pa·s/m)", color=color_mag)
+    ax1.semilogx(freq, z_mag, color=color_mag, label="|Z|")
+    ax1.tick_params(axis="y", labelcolor=color_mag)
+
+    ax2 = ax1.twinx()
+    color_phase = "tab:red"
+    ax2.set_ylabel("∠Z (degrees)", color=color_phase)
+    ax2.semilogx(freq, z_angle, color=color_phase, linestyle="--", label="∠Z")
+    ax2.tick_params(axis="y", labelcolor=color_phase)
+
+    ax1.set_title("Throat Impedance vs Frequency")
+    ax1.grid(True, which="both", ls="--", alpha=0.5)
+
+    # Combined legend
+    lines1, labels1 = ax1.get_legend_handles_labels()
+    lines2, labels2 = ax2.get_legend_handles_labels()
+    ax1.legend(lines1 + lines2, labels1 + labels2, loc="upper right")
+
+    plt.tight_layout()
+    plt.savefig(output_file, dpi=150)
+    plt.close()
+    print(f"Impedance plot saved to {output_file}")
+
+
+def main():
+    """CLI for impedance plotting."""
+    parser = argparse.ArgumentParser(description="Plot throat impedance from solver CSV.")
+    parser.add_argument("csv_file", type=str, help="Input CSV with frequency, z_real, z_imag columns.")
+    parser.add_argument("output_file", type=str, help="Output image path.")
+    args = parser.parse_args()
+    plot_impedance(args.csv_file, args.output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/horn-analysis/src/horn_analysis/kpi.py
+++ b/packages/horn-analysis/src/horn_analysis/kpi.py
@@ -1,0 +1,152 @@
+"""KPI extraction from horn frequency response data.
+
+Computes key performance indicators from a CSV with (frequency, spl) columns:
+- f3_low / f3_high: -3 dB cutoff frequencies
+- bandwidth_hz / bandwidth_octaves: usable bandwidth
+- passband_ripple_db: max - min SPL within the -3 dB band
+- average_sensitivity_db: mean SPL in the passband
+- peak_spl_db / peak_frequency_hz: maximum SPL point
+"""
+
+import json
+import argparse
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+from scipy.interpolate import interp1d
+from scipy.optimize import brentq
+
+
+@dataclass
+class HornKPI:
+    """Key performance indicators for a horn frequency response."""
+    peak_spl_db: float
+    peak_frequency_hz: float
+    f3_low_hz: Optional[float]
+    f3_high_hz: Optional[float]
+    bandwidth_hz: Optional[float]
+    bandwidth_octaves: Optional[float]
+    passband_ripple_db: Optional[float]
+    average_sensitivity_db: Optional[float]
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def extract_kpis(csv_path: str) -> HornKPI:
+    """Extract KPIs from a frequency response CSV file.
+
+    Args:
+        csv_path: Path to CSV with 'frequency' and 'spl' columns.
+
+    Returns:
+        HornKPI dataclass with computed metrics.
+    """
+    df = pd.read_csv(csv_path)
+    freq = df["frequency"].values
+    spl = df["spl"].values
+
+    # Peak
+    peak_idx = np.argmax(spl)
+    peak_spl = float(spl[peak_idx])
+    peak_freq = float(freq[peak_idx])
+
+    # -3 dB threshold
+    threshold = peak_spl - 3.0
+
+    # Interpolate for root-finding
+    spl_interp = interp1d(freq, spl, kind="linear", fill_value="extrapolate")
+
+    def spl_minus_threshold(f):
+        return float(spl_interp(f)) - threshold
+
+    # Find f3_low: search from lowest freq up to peak
+    f3_low = _find_crossing(spl_minus_threshold, freq[0], freq[peak_idx], direction="rising")
+
+    # Find f3_high: search from peak to highest freq
+    f3_high = _find_crossing(spl_minus_threshold, freq[peak_idx], freq[-1], direction="falling")
+
+    # Derived KPIs
+    bandwidth_hz = None
+    bandwidth_octaves = None
+    passband_ripple = None
+    avg_sensitivity = None
+
+    if f3_low is not None and f3_high is not None:
+        bandwidth_hz = f3_high - f3_low
+        bandwidth_octaves = np.log2(f3_high / f3_low) if f3_low > 0 else None
+
+        # Passband: frequencies within [f3_low, f3_high]
+        mask = (freq >= f3_low) & (freq <= f3_high)
+        if np.any(mask):
+            passband_spl = spl[mask]
+            passband_ripple = float(np.max(passband_spl) - np.min(passband_spl))
+            avg_sensitivity = float(np.mean(passband_spl))
+
+    return HornKPI(
+        peak_spl_db=peak_spl,
+        peak_frequency_hz=peak_freq,
+        f3_low_hz=f3_low,
+        f3_high_hz=f3_high,
+        bandwidth_hz=bandwidth_hz,
+        bandwidth_octaves=float(bandwidth_octaves) if bandwidth_octaves is not None else None,
+        passband_ripple_db=passband_ripple,
+        average_sensitivity_db=avg_sensitivity,
+    )
+
+
+def _find_crossing(func, f_start, f_end, direction="rising"):
+    """Find where func crosses zero between f_start and f_end.
+
+    For 'rising', we look for a transition from negative to positive.
+    For 'falling', we look for a transition from positive to negative.
+
+    Returns the crossing frequency, or None if not found.
+    """
+    # Sample the function at multiple points to find a bracket
+    num_samples = 200
+    f_samples = np.linspace(f_start, f_end, num_samples)
+    vals = np.array([func(f) for f in f_samples])
+
+    if direction == "rising":
+        # Find first interval where val goes from < 0 to >= 0
+        for i in range(len(vals) - 1):
+            if vals[i] < 0 and vals[i + 1] >= 0:
+                try:
+                    return float(brentq(func, f_samples[i], f_samples[i + 1]))
+                except ValueError:
+                    continue
+    else:  # falling
+        # Find last interval where val goes from >= 0 to < 0
+        for i in range(len(vals) - 2, -1, -1):
+            if vals[i] >= 0 and vals[i + 1] < 0:
+                try:
+                    return float(brentq(func, f_samples[i], f_samples[i + 1]))
+                except ValueError:
+                    continue
+
+    return None
+
+
+def main():
+    """CLI for KPI extraction."""
+    parser = argparse.ArgumentParser(description="Extract KPIs from horn frequency response CSV.")
+    parser.add_argument("csv_file", type=str, help="Input CSV with frequency,spl columns.")
+    parser.add_argument("--output", type=str, default=None, help="Output JSON file (default: stdout).")
+    args = parser.parse_args()
+
+    kpis = extract_kpis(args.csv_file)
+    result = json.dumps(kpis.to_dict(), indent=2)
+
+    if args.output:
+        Path(args.output).write_text(result)
+        print(f"KPIs written to {args.output}")
+    else:
+        print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/horn-analysis/src/horn_analysis/phase_plot.py
+++ b/packages/horn-analysis/src/horn_analysis/phase_plot.py
@@ -1,0 +1,80 @@
+"""Phase response plotting: unwrapped phase and optional group delay vs frequency."""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+def plot_phase(csv_file: str, output_file: str, group_delay: bool = False):
+    """Plot phase response from solver CSV output.
+
+    Expects CSV columns: frequency, phase_deg.
+
+    Args:
+        csv_file: Input CSV path.
+        output_file: Output image path.
+        group_delay: If True, add a second subplot with group delay.
+    """
+    df = pd.read_csv(csv_file)
+    freq = df["frequency"].values
+    phase_deg = df["phase_deg"].values
+
+    # Unwrap phase for continuous display
+    phase_rad = np.radians(phase_deg)
+    phase_unwrapped_rad = np.unwrap(phase_rad)
+    phase_unwrapped_deg = np.degrees(phase_unwrapped_rad)
+
+    if group_delay:
+        fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 8), sharex=True)
+    else:
+        fig, ax1 = plt.subplots(figsize=(10, 6))
+
+    ax1.semilogx(freq, phase_unwrapped_deg, color="tab:blue")
+    ax1.set_ylabel("Phase (degrees)")
+    ax1.set_title("Phase Response vs Frequency")
+    ax1.grid(True, which="both", ls="--", alpha=0.5)
+
+    if group_delay:
+        # Group delay: τ_g = -dφ/dω = -(1/(2π)) * dφ_rad/df
+        if len(freq) > 1:
+            dphi = np.diff(phase_unwrapped_rad)
+            df_vals = np.diff(freq)
+            tau_g = -dphi / (2 * np.pi * df_vals)
+            freq_mid = (freq[:-1] + freq[1:]) / 2
+            # Convert to milliseconds
+            tau_g_ms = tau_g * 1000
+
+            ax2.semilogx(freq_mid, tau_g_ms, color="tab:green")
+            ax2.set_ylabel("Group Delay (ms)")
+            ax2.set_xlabel("Frequency (Hz)")
+            ax2.grid(True, which="both", ls="--", alpha=0.5)
+        else:
+            ax2.set_xlabel("Frequency (Hz)")
+            ax2.text(0.5, 0.5, "Insufficient data for group delay",
+                     ha="center", va="center", transform=ax2.transAxes)
+    else:
+        ax1.set_xlabel("Frequency (Hz)")
+
+    plt.tight_layout()
+    plt.savefig(output_file, dpi=150)
+    plt.close()
+    print(f"Phase plot saved to {output_file}")
+
+
+def main():
+    """CLI for phase response plotting."""
+    parser = argparse.ArgumentParser(description="Plot phase response from solver CSV.")
+    parser.add_argument("csv_file", type=str, help="Input CSV with frequency, phase_deg columns.")
+    parser.add_argument("output_file", type=str, help="Output image path.")
+    parser.add_argument("--group-delay", action="store_true", help="Include group delay subplot.")
+    args = parser.parse_args()
+    plot_phase(args.csv_file, args.output_file, group_delay=args.group_delay)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/horn-analysis/tests/test_analysis.py
+++ b/packages/horn-analysis/tests/test_analysis.py
@@ -1,4 +1,7 @@
+import json
+
 import pytest
+import numpy as np
 import pandas as pd
 from pathlib import Path
 
@@ -46,5 +49,184 @@ class TestCompareHorns:
 
         output = tmp_path / "comparison.png"
         plot_comparison(str(sample_csv), "Horn A", str(csv_b), "Horn B", str(output))
+        assert output.exists()
+        assert output.stat().st_size > 0
+
+
+class TestKPI:
+    """Tests for KPI extraction."""
+
+    @pytest.fixture
+    def bandpass_csv(self, tmp_path):
+        """Create a CSV with a clear bandpass shape for predictable KPIs."""
+        csv_path = tmp_path / "bandpass.csv"
+        freq = np.geomspace(100, 10000, 100)
+        # Simulate a bandpass: peak at 2kHz, rolls off below 500Hz and above 6kHz
+        spl = 90 - 10 * ((np.log10(freq / 2000)) ** 2) * 20
+        # Clip to a reasonable range
+        spl = np.clip(spl, 50, 95)
+        df = pd.DataFrame({"frequency": freq, "spl": spl})
+        df.to_csv(csv_path, index=False)
+        return csv_path
+
+    def test_extract_kpis_returns_dataclass(self, bandpass_csv):
+        from horn_analysis.kpi import extract_kpis, HornKPI
+
+        kpis = extract_kpis(str(bandpass_csv))
+        assert isinstance(kpis, HornKPI)
+
+    def test_peak_detection(self, bandpass_csv):
+        from horn_analysis.kpi import extract_kpis
+
+        kpis = extract_kpis(str(bandpass_csv))
+        assert kpis.peak_spl_db > 0
+        assert kpis.peak_frequency_hz > 0
+
+    def test_f3_points_bracket_peak(self, bandpass_csv):
+        from horn_analysis.kpi import extract_kpis
+
+        kpis = extract_kpis(str(bandpass_csv))
+        assert kpis.f3_low_hz is not None
+        assert kpis.f3_high_hz is not None
+        assert kpis.f3_low_hz < kpis.peak_frequency_hz
+        assert kpis.f3_high_hz > kpis.peak_frequency_hz
+
+    def test_bandwidth_positive(self, bandpass_csv):
+        from horn_analysis.kpi import extract_kpis
+
+        kpis = extract_kpis(str(bandpass_csv))
+        assert kpis.bandwidth_hz is not None
+        assert kpis.bandwidth_hz > 0
+        assert kpis.bandwidth_octaves is not None
+        assert kpis.bandwidth_octaves > 0
+
+    def test_passband_ripple_nonnegative(self, bandpass_csv):
+        from horn_analysis.kpi import extract_kpis
+
+        kpis = extract_kpis(str(bandpass_csv))
+        assert kpis.passband_ripple_db is not None
+        assert kpis.passband_ripple_db >= 0
+
+    def test_to_dict_and_json(self, bandpass_csv):
+        from horn_analysis.kpi import extract_kpis
+
+        kpis = extract_kpis(str(bandpass_csv))
+        d = kpis.to_dict()
+        assert isinstance(d, dict)
+        assert "peak_spl_db" in d
+        # Should be JSON-serializable
+        json_str = json.dumps(d)
+        assert len(json_str) > 0
+
+    def test_flat_response_no_f3(self, tmp_path):
+        """A flat response at the peak should have no -3dB crossing below the peak."""
+        from horn_analysis.kpi import extract_kpis
+
+        csv_path = tmp_path / "flat.csv"
+        freq = np.geomspace(100, 10000, 50)
+        spl = np.full_like(freq, 90.0)
+        pd.DataFrame({"frequency": freq, "spl": spl}).to_csv(csv_path, index=False)
+
+        kpis = extract_kpis(str(csv_path))
+        assert kpis.peak_spl_db == pytest.approx(90.0)
+        # With perfectly flat response, there's no -3dB crossing
+        assert kpis.f3_low_hz is None
+        assert kpis.f3_high_hz is None
+
+
+class TestMultiComparison:
+    """Tests for multi-horn comparison plotting."""
+
+    def _make_csv(self, tmp_path, name, spl_offset=0):
+        csv_path = tmp_path / name
+        freq = np.geomspace(100, 10000, 50)
+        spl = 85 + spl_offset - 5 * ((np.log10(freq / 2000)) ** 2) * 10
+        pd.DataFrame({"frequency": freq, "spl": spl}).to_csv(csv_path, index=False)
+        return csv_path
+
+    def test_multi_comparison_creates_image(self, tmp_path):
+        from horn_analysis.compare import plot_multi_comparison
+
+        csv_a = self._make_csv(tmp_path, "a.csv", spl_offset=0)
+        csv_b = self._make_csv(tmp_path, "b.csv", spl_offset=3)
+        csv_c = self._make_csv(tmp_path, "c.csv", spl_offset=-2)
+
+        output = tmp_path / "multi.png"
+        plot_multi_comparison(
+            [(str(csv_a), "Horn A"), (str(csv_b), "Horn B"), (str(csv_c), "Horn C")],
+            str(output),
+        )
+        assert output.exists()
+        assert output.stat().st_size > 0
+
+    def test_multi_comparison_with_kpi_table(self, tmp_path):
+        from horn_analysis.compare import plot_multi_comparison
+
+        csv_a = self._make_csv(tmp_path, "a.csv")
+        csv_b = self._make_csv(tmp_path, "b.csv", spl_offset=5)
+
+        output = tmp_path / "multi_kpi.png"
+        plot_multi_comparison(
+            [(str(csv_a), "Horn A"), (str(csv_b), "Horn B")],
+            str(output),
+            kpi_table=True,
+        )
+        assert output.exists()
+        assert output.stat().st_size > 0
+
+    def test_parse_file_label(self):
+        from horn_analysis.compare import parse_file_label
+
+        assert parse_file_label("data.csv:My Horn") == ("data.csv", "My Horn")
+        path, label = parse_file_label("results/final.csv")
+        assert path == "results/final.csv"
+        assert label == "final"
+
+
+@pytest.fixture
+def solver_csv_with_impedance_phase(tmp_path):
+    """Create a CSV with all solver output columns including impedance and phase."""
+    csv_path = tmp_path / "full_results.csv"
+    freq = np.geomspace(500, 8000, 50)
+    spl = 85 - 5 * ((np.log10(freq / 2000)) ** 2) * 10
+    phase_deg = -np.cumsum(np.ones_like(freq) * 15)  # Decreasing phase
+    # Simulate impedance: real part ~400, imaginary varies
+    z_real = 400 + 50 * np.sin(2 * np.pi * np.log10(freq))
+    z_imag = 100 * np.cos(2 * np.pi * np.log10(freq))
+    df = pd.DataFrame({
+        "frequency": freq,
+        "spl": spl,
+        "phase_deg": phase_deg,
+        "z_real": z_real,
+        "z_imag": z_imag,
+    })
+    df.to_csv(csv_path, index=False)
+    return csv_path
+
+
+class TestImpedancePlot:
+    def test_impedance_plot_creates_image(self, solver_csv_with_impedance_phase, tmp_path):
+        from horn_analysis.impedance_plot import plot_impedance
+
+        output = tmp_path / "impedance.png"
+        plot_impedance(str(solver_csv_with_impedance_phase), str(output))
+        assert output.exists()
+        assert output.stat().st_size > 0
+
+
+class TestPhasePlot:
+    def test_phase_plot_creates_image(self, solver_csv_with_impedance_phase, tmp_path):
+        from horn_analysis.phase_plot import plot_phase
+
+        output = tmp_path / "phase.png"
+        plot_phase(str(solver_csv_with_impedance_phase), str(output))
+        assert output.exists()
+        assert output.stat().st_size > 0
+
+    def test_phase_plot_with_group_delay(self, solver_csv_with_impedance_phase, tmp_path):
+        from horn_analysis.phase_plot import plot_phase
+
+        output = tmp_path / "phase_gd.png"
+        plot_phase(str(solver_csv_with_impedance_phase), str(output), group_delay=True)
         assert output.exists()
         assert output.stat().st_size > 0

--- a/packages/horn-geometry/src/horn_geometry/generator.py
+++ b/packages/horn-geometry/src/horn_geometry/generator.py
@@ -1,74 +1,189 @@
 import gmsh
+import numpy as np
 from pathlib import Path
+from typing import Callable
 import argparse
+
+
+def _loft_horn_profile(
+    radius_func: Callable[[float], float],
+    length: float,
+    num_sections: int,
+    output_file: Path,
+    model_name: str,
+) -> Path:
+    """Shared helper that lofts through circular cross-sections along the z-axis.
+
+    Args:
+        radius_func: Function mapping z-position [0, length] to radius.
+        length: Horn length along z-axis (m).
+        num_sections: Number of intermediate cross-sections (including throat and mouth).
+        output_file: Path for the output STEP file.
+        model_name: Name for the gmsh model.
+
+    Returns:
+        Path to the generated STEP file.
+    """
+    gmsh.initialize()
+    gmsh.model.add(model_name)
+    gmsh.option.setNumber("General.Terminal", 1)
+
+    z_positions = np.linspace(0, length, num_sections)
+    curve_loops = []
+
+    for z in z_positions:
+        r = radius_func(z)
+        wire = gmsh.model.occ.addCircle(0, 0, z, r)
+        loop = gmsh.model.occ.addCurveLoop([wire])
+        curve_loops.append(loop)
+
+    # Create end-cap plane surfaces (throat and mouth)
+    gmsh.model.occ.addPlaneSurface([curve_loops[0]])
+    gmsh.model.occ.addPlaneSurface([curve_loops[-1]])
+
+    # Loft through all sections
+    gmsh.model.occ.addThruSections(curve_loops)
+    gmsh.model.occ.synchronize()
+
+    gmsh.write(str(output_file))
+    gmsh.finalize()
+
+    print(str(output_file))
+    return output_file
+
 
 def create_conical_horn(
     throat_radius: float,
     mouth_radius: float,
     length: float,
     output_file: Path,
+    num_sections: int = 2,
 ) -> Path:
+    """Generate a conical horn STEP file.
+
+    A conical horn has a linear radius profile: r(z) = r_throat + (r_mouth - r_throat) * z / L.
+    Only 2 sections are needed (throat + mouth), but more can be used for consistency.
     """
-    Generates a simple conical horn geometry using gmsh's OpenCASCADE kernel
-    and saves it as a STEP file.
+
+    def radius_func(z: float) -> float:
+        return throat_radius + (mouth_radius - throat_radius) * z / length
+
+    return _loft_horn_profile(radius_func, length, num_sections, output_file, "conical_horn")
+
+
+def create_exponential_horn(
+    throat_radius: float,
+    mouth_radius: float,
+    length: float,
+    output_file: Path,
+    num_sections: int = 20,
+) -> Path:
+    """Generate an exponential horn STEP file.
+
+    Radius profile: r(z) = r_throat * exp(m * z / L)
+    where m = ln(r_mouth / r_throat).
+    """
+    m = np.log(mouth_radius / throat_radius)
+
+    def radius_func(z: float) -> float:
+        return throat_radius * np.exp(m * z / length)
+
+    return _loft_horn_profile(radius_func, length, num_sections, output_file, "exponential_horn")
+
+
+def create_hyperbolic_horn(
+    throat_radius: float,
+    mouth_radius: float,
+    length: float,
+    output_file: Path,
+    num_sections: int = 20,
+) -> Path:
+    """Generate a hyperbolic (hypex) horn STEP file.
+
+    Radius profile: r(z) = r_throat * cosh(m * z / L)
+    where m = acosh(r_mouth / r_throat).
+    """
+    m = np.arccosh(mouth_radius / throat_radius)
+
+    def radius_func(z: float) -> float:
+        return throat_radius * np.cosh(m * z / length)
+
+    return _loft_horn_profile(radius_func, length, num_sections, output_file, "hyperbolic_horn")
+
+
+_PROFILE_DISPATCH = {
+    "conical": create_conical_horn,
+    "exponential": create_exponential_horn,
+    "hyperbolic": create_hyperbolic_horn,
+}
+
+
+def create_horn(
+    profile: str,
+    throat_radius: float,
+    mouth_radius: float,
+    length: float,
+    output_file: Path,
+    num_sections: int = 20,
+) -> Path:
+    """Dispatch to the appropriate horn profile generator.
 
     Args:
-        throat_radius: The radius of the horn's throat (inlet).
-        mouth_radius: The radius of the horn's mouth (outlet).
-        length: The length of the horn along the z-axis.
-        output_file: The exact path to save the output STEP file to.
+        profile: One of "conical", "exponential", "hyperbolic".
+        throat_radius: Throat radius (m).
+        mouth_radius: Mouth radius (m).
+        length: Horn length (m).
+        output_file: Output STEP file path.
+        num_sections: Number of cross-sections for lofting.
 
     Returns:
-        The path to the generated STEP file.
+        Path to the generated STEP file.
     """
-    gmsh.initialize()
-    gmsh.model.add("conical_horn")
-    gmsh.option.setNumber("General.Terminal", 1)
+    if profile not in _PROFILE_DISPATCH:
+        raise ValueError(f"Unknown profile '{profile}'. Choose from: {list(_PROFILE_DISPATCH.keys())}")
+    return _PROFILE_DISPATCH[profile](
+        throat_radius=throat_radius,
+        mouth_radius=mouth_radius,
+        length=length,
+        output_file=output_file,
+        num_sections=num_sections,
+    )
 
-    # Create the throat and mouth circles (wires)
-    throat_wire = gmsh.model.occ.addCircle(0, 0, 0, throat_radius)
-    mouth_wire = gmsh.model.occ.addCircle(0, 0, length, mouth_radius)
-
-    # Create curve loops from the wires
-    throat_loop = gmsh.model.occ.addCurveLoop([throat_wire])
-    mouth_loop = gmsh.model.occ.addCurveLoop([mouth_wire])
-
-    # Create plane surfaces from the loops
-    gmsh.model.occ.addPlaneSurface([throat_loop])
-    gmsh.model.occ.addPlaneSurface([mouth_loop])
-
-    # Create the lofted solid (conical section)
-    gmsh.model.occ.addThruSections([throat_loop, mouth_loop])
-
-    gmsh.model.occ.synchronize()
-
-    # Export the model to a STEP file
-    gmsh.write(str(output_file))
-
-    gmsh.finalize()
-
-    # Print the final path to stdout so it can be captured by the calling script.
-    print(str(output_file))
-    return output_file
 
 def main():
-    """A simple command-line interface for the generator."""
-    parser = argparse.ArgumentParser(description="Generate a conical horn STEP file.")
+    """Command-line interface for the horn geometry generator."""
+    parser = argparse.ArgumentParser(description="Generate a horn STEP file.")
     parser.add_argument("--throat-radius", type=float, required=True)
     parser.add_argument("--mouth-radius", type=float, required=True)
     parser.add_argument("--length", type=float, required=True)
     parser.add_argument("--output-file", type=str, required=True)
+    parser.add_argument(
+        "--profile",
+        type=str,
+        choices=["conical", "exponential", "hyperbolic"],
+        default="conical",
+        help="Horn flare profile (default: conical).",
+    )
+    parser.add_argument(
+        "--num-sections",
+        type=int,
+        default=20,
+        help="Number of cross-sections for lofting (default: 20).",
+    )
     args = parser.parse_args()
 
     output_path = Path(args.output_file)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    create_conical_horn(
+    create_horn(
+        profile=args.profile,
         throat_radius=args.throat_radius,
         mouth_radius=args.mouth_radius,
         length=args.length,
         output_file=output_path,
+        num_sections=args.num_sections,
     )
+
 
 if __name__ == "__main__":
     main()

--- a/packages/horn-geometry/tests/test_profiles.py
+++ b/packages/horn-geometry/tests/test_profiles.py
@@ -1,0 +1,187 @@
+"""Tests for exponential and hyperbolic horn geometry generators."""
+
+import pytest
+import numpy as np
+from pathlib import Path
+
+try:
+    import gmsh
+except ImportError:
+    gmsh = None
+
+from horn_geometry.generator import (
+    create_conical_horn,
+    create_exponential_horn,
+    create_hyperbolic_horn,
+    create_horn,
+)
+
+
+@pytest.mark.skipif(gmsh is None, reason="gmsh not available")
+class TestProfileSmoke:
+    """Smoke tests: each profile creates a non-empty STEP file."""
+
+    @pytest.fixture(params=["conical", "exponential", "hyperbolic"])
+    def profile_name(self, request):
+        return request.param
+
+    def test_create_horn_produces_step_file(self, profile_name, tmp_path):
+        output = tmp_path / f"{profile_name}_horn.step"
+        result = create_horn(
+            profile=profile_name,
+            throat_radius=0.025,
+            mouth_radius=0.1,
+            length=0.3,
+            output_file=output,
+            num_sections=10,
+        )
+        assert result.exists()
+        assert result.stat().st_size > 0
+
+
+@pytest.mark.skipif(gmsh is None, reason="gmsh not available")
+class TestProfileGeometricValidation:
+    """Validate geometric properties against analytical formulae."""
+
+    THROAT_R = 0.025
+    MOUTH_R = 0.1
+    LENGTH = 0.3
+
+    def _analytical_volume_conical(self, r_t, r_m, L):
+        """V = (pi/3) * L * (R^2 + R*r + r^2)"""
+        return (np.pi / 3) * L * (r_m**2 + r_m * r_t + r_t**2)
+
+    def _analytical_volume_exponential(self, r_t, r_m, L):
+        """V = integral_0^L pi * [r_t * exp(m*z/L)]^2 dz
+        = pi * r_t^2 * L / (2m) * [exp(2m) - 1]
+        where m = ln(r_m / r_t).
+        """
+        m = np.log(r_m / r_t)
+        return np.pi * r_t**2 * L / (2 * m) * (np.exp(2 * m) - 1)
+
+    def _analytical_volume_hyperbolic(self, r_t, r_m, L):
+        """V = integral_0^L pi * [r_t * cosh(m*z/L)]^2 dz
+        = pi * r_t^2 * L * [1/2 + sinh(2m) / (4m)]
+        where m = acosh(r_m / r_t).
+        """
+        m = np.arccosh(r_m / r_t)
+        return np.pi * r_t**2 * L * (0.5 + np.sinh(2 * m) / (4 * m))
+
+    def _get_step_volume(self, step_file: Path) -> float:
+        """Load a STEP file with gmsh and compute the volume of all 3D entities."""
+        gmsh.initialize()
+        gmsh.option.setNumber("General.Terminal", 0)
+        gmsh.model.add("volume_check")
+        gmsh.model.occ.importShapes(str(step_file))
+        gmsh.model.occ.synchronize()
+
+        volumes = gmsh.model.occ.getEntities(dim=3)
+        total_volume = 0.0
+        for dim, tag in volumes:
+            mass = gmsh.model.occ.getMass(dim, tag)
+            total_volume += mass
+
+        gmsh.finalize()
+        return total_volume
+
+    def test_conical_volume(self, tmp_path):
+        step = create_conical_horn(
+            self.THROAT_R, self.MOUTH_R, self.LENGTH,
+            tmp_path / "conical.step", num_sections=2,
+        )
+        expected = self._analytical_volume_conical(self.THROAT_R, self.MOUTH_R, self.LENGTH)
+        actual = self._get_step_volume(step)
+        assert np.isclose(actual, expected, rtol=0.01), (
+            f"Conical volume mismatch: expected={expected:.6e}, actual={actual:.6e}"
+        )
+
+    def test_exponential_volume(self, tmp_path):
+        step = create_exponential_horn(
+            self.THROAT_R, self.MOUTH_R, self.LENGTH,
+            tmp_path / "exponential.step", num_sections=40,
+        )
+        expected = self._analytical_volume_exponential(self.THROAT_R, self.MOUTH_R, self.LENGTH)
+        actual = self._get_step_volume(step)
+        assert np.isclose(actual, expected, rtol=0.01), (
+            f"Exponential volume mismatch: expected={expected:.6e}, actual={actual:.6e}"
+        )
+
+    def test_hyperbolic_volume(self, tmp_path):
+        step = create_hyperbolic_horn(
+            self.THROAT_R, self.MOUTH_R, self.LENGTH,
+            tmp_path / "hyperbolic.step", num_sections=40,
+        )
+        expected = self._analytical_volume_hyperbolic(self.THROAT_R, self.MOUTH_R, self.LENGTH)
+        actual = self._get_step_volume(step)
+        assert np.isclose(actual, expected, rtol=0.01), (
+            f"Hyperbolic volume mismatch: expected={expected:.6e}, actual={actual:.6e}"
+        )
+
+    def test_throat_mouth_radii_match(self, tmp_path):
+        """Verify that throat (z=0) and mouth (z=L) surfaces have correct areas."""
+        for profile in ["exponential", "hyperbolic"]:
+            step = create_horn(
+                profile=profile,
+                throat_radius=self.THROAT_R,
+                mouth_radius=self.MOUTH_R,
+                length=self.LENGTH,
+                output_file=tmp_path / f"{profile}_area_check.step",
+                num_sections=20,
+            )
+            gmsh.initialize()
+            gmsh.option.setNumber("General.Terminal", 0)
+            gmsh.model.add("area_check")
+            gmsh.model.occ.importShapes(str(step))
+            gmsh.model.occ.synchronize()
+
+            surfaces = gmsh.model.occ.getEntities(dim=2)
+            throat_area = None
+            mouth_area = None
+            for dim, tag in surfaces:
+                com = gmsh.model.occ.getCenterOfMass(dim, tag)
+                if np.isclose(com[2], 0.0, atol=1e-6):
+                    throat_area = gmsh.model.occ.getMass(dim, tag)
+                elif np.isclose(com[2], self.LENGTH, atol=1e-6):
+                    mouth_area = gmsh.model.occ.getMass(dim, tag)
+
+            gmsh.finalize()
+
+            expected_throat = np.pi * self.THROAT_R**2
+            expected_mouth = np.pi * self.MOUTH_R**2
+            assert throat_area is not None, f"{profile}: no throat face found at z=0"
+            assert mouth_area is not None, f"{profile}: no mouth face found at z=L"
+            assert np.isclose(throat_area, expected_throat, rtol=0.01), (
+                f"{profile} throat area: expected={expected_throat:.6e}, actual={throat_area:.6e}"
+            )
+            assert np.isclose(mouth_area, expected_mouth, rtol=0.01), (
+                f"{profile} mouth area: expected={expected_mouth:.6e}, actual={mouth_area:.6e}"
+            )
+
+
+@pytest.mark.skipif(gmsh is None, reason="gmsh not available")
+class TestCreateHornDispatch:
+    """Test the create_horn dispatch function."""
+
+    def test_invalid_profile_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="Unknown profile"):
+            create_horn(
+                profile="parabolic",
+                throat_radius=0.025,
+                mouth_radius=0.1,
+                length=0.3,
+                output_file=tmp_path / "bad.step",
+            )
+
+    def test_conical_backward_compatible(self, tmp_path):
+        """create_horn('conical', ...) should produce the same result as create_conical_horn()."""
+        output = tmp_path / "dispatch.step"
+        result = create_horn(
+            profile="conical",
+            throat_radius=0.025,
+            mouth_radius=0.1,
+            length=0.3,
+            output_file=output,
+            num_sections=2,
+        )
+        assert result.exists()
+        assert result.stat().st_size > 0


### PR DESCRIPTION
## Summary

- **#33**: Exponential and hyperbolic geometry generators via shared `_loft_horn_profile()` helper, with `--profile` / `--num-sections` CLI flags and Nextflow pipeline params
- **#35a**: KPI extraction module (`f3_low`, `f3_high`, bandwidth, ripple, sensitivity, peak) → JSON output
- **#35b**: Multi-horn comparison plot (N files) with optional KPI summary table
- **#35c**: Throat impedance output from solver (`z_real`, `z_imag` CSV columns)
- **#35d**: Phase response output from solver (`phase_deg` CSV column)
- **#35e**: Impedance plot (dual y-axis: |Z| + ∠Z) and phase plot (unwrapped phase + group delay)

## Test plan

- [x] `pytest packages/horn-geometry/tests/test_profiles.py` — 9/9 passed (smoke, volume validation, area checks, dispatch)
- [x] `pytest packages/horn-analysis/tests/test_analysis.py` — 16/16 passed (KPI, comparison, impedance plot, phase plot)
- [ ] Run `nextflow run main.nf --profile exponential` end-to-end and verify new CSV columns + plots
- [ ] Visual inspection of generated STEP files in gmsh/FreeCAD for all 3 profiles
- [ ] CI passes on PR

Closes #33. Partially addresses #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)