### PR TITLE
chore: remove dead params.test_outdir and hardcoded Python paths

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -22,7 +22,6 @@ params.mesh_size = 0.01    // Target mesh element size in meters
 // Execution Settings
 params.num_bands = 8       // Number of parallel jobs for the solver
 params.outdir = "./results"
-params.test_outdir = null  // for testing purposes
 
 // Auto mode settings
 params.target_f_low = 500

--- a/packages/horn-analysis/Dockerfile
+++ b/packages/horn-analysis/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get update && apt-get install -y procps && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 # Copy the installed packages from the builder stage.
-COPY --from=builder /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
+ARG PYTHON_SITELIB=/usr/local/lib/python3.10/site-packages
+COPY --from=builder ${PYTHON_SITELIB} ${PYTHON_SITELIB}
 COPY --from=builder /usr/local/bin /usr/local/bin
 
 # --- Test Stage ---

--- a/packages/horn-geometry/Dockerfile
+++ b/packages/horn-geometry/Dockerfile
@@ -22,7 +22,8 @@ FROM base as production
 WORKDIR /app
 
 # Copy the installed packages from the builder stage.
-COPY --from=builder /usr/local/lib/python3.10/dist-packages /usr/local/lib/python3.10/dist-packages
+ARG PYTHON_SITELIB=/usr/local/lib/python3.10/dist-packages
+COPY --from=builder ${PYTHON_SITELIB} ${PYTHON_SITELIB}
 
 # Copy the generator script, which is the entrypoint.
 COPY --from=builder /app/packages/horn-geometry/src/horn_geometry/generator.py /app/generator.py


### PR DESCRIPTION
## Summary
- Remove unused `params.test_outdir = null` declaration from `main.nf` (closes #29)
- Use `ARG PYTHON_SITELIB` in both Dockerfiles so the Python site-packages path is defined once and easy to update when bumping base images (closes #25)

## Test plan
- [ ] `grep -r test_outdir` returns no results
- [ ] `docker build -f packages/horn-geometry/Dockerfile -t horn-geometry:test --target test .` builds successfully
- [ ] `docker build -f packages/horn-analysis/Dockerfile -t horn-analysis:test --target test .` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)