### PR TITLE
fix: prevent CI jobs from running twice on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   test_nextflow:


### PR DESCRIPTION
## Summary

- Fix `on: [push, pull_request]` trigger that caused every CI job to run twice when pushing to a branch with an open PR
- Restrict `push` trigger to `main` only (needed for Docker image publishing); `pull_request` covers PR branches

Closes #66

## Test plan

- [ ] This PR itself should show each job running only once (not duplicated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)